### PR TITLE
Add pruner category.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,6 @@ clean:
 	rm -rf optunahub-registry
 	rm -rf public
 	rm -rf content/samplers*
+	rm -rf content/pruners*
 	rm -rf content/vizualization*
 	rm -f .hugo_build.lock

--- a/hugo_build.py
+++ b/hugo_build.py
@@ -4,7 +4,7 @@ import shutil
 
 def main():
     registry_dir = "optunahub-registry/package"
-    categories = ["samplers", "visualization"]
+    categories = ["samplers", "pruners", "visualization"]
     for c in categories:
         packages = os.listdir(f"{registry_dir}/{c}")
         for p in packages:

--- a/themes/index/layouts/partials/quick-list.html
+++ b/themes/index/layouts/partials/quick-list.html
@@ -1,6 +1,7 @@
 <div class="all-tags">
   <ul class="tagsList">
     <li><a href="{{ .Site.BaseURL }}/tags/sampler">Sampler</a></li>
+    <li><a href="{{ .Site.BaseURL }}/tags/pruner">Pruner</a></li>
     <li><a href="{{ .Site.BaseURL }}/tags/visualization">Visualization</a></li>
     <!-- {{ range .Site.Taxonomies.optuna_version }}
         <li><a href="{{ .Page.Permalink }}">v{{ .Page.Title }}</a></li>


### PR DESCRIPTION
## Motivation

The current Optunahub supports two features, i.e., sampling and visualization, but pruning is also an important feature of Optuna. This PR aims to add the `pruners` category to Optunahub.

## Changes

- Add `pruners` to categories
- Add `pruners` to the tag list

Note that this PR depends on https://github.com/optuna/optunahub-registry/pull/64 since it requires at least one pruner to build the web site properly.