### PR TITLE
Update copyright in footer.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ baseURL: https://hub.optuna.org/
 languageCode: en-us
 title: OptunaHub
 theme: index
+copyright: "© 2024 Preferred Networks, Inc. All rights reserved."
 pygmentsUseClasses: true
 enableInlineShortcodes: true
 enableGitInfo: true


### PR DESCRIPTION
## Motivation

Currently, the copyright in the footer is automatically generated using the site name.
It should be aligned with https://optuna.org.

## Changes

- Update copyright in the footer.
- The year was changed to 2024 since we made this site in this year.

Screenshot:
<img width="405" alt="image" src="https://github.com/optuna/optunahub-web/assets/3255979/00b9c22c-63fc-4a75-aefa-03b658c12e73">
