### PR TITLE
Fix CSS for img

### DIFF
--- a/themes/hub/assets/css/main.css
+++ b/themes/hub/assets/css/main.css
@@ -24,3 +24,8 @@ a:hover {
 .highlight pre {
   padding: 0.25rem 0.5rem;
 }
+
+img {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
## Motivation

Fix CSS to keep images not too large.

## Description of the changes

Set max-width to `img`.

## Example

https://hub.optuna.org/samplers/bbo_rietveld/

Before
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ee2a29de-a8c7-46c6-9932-4baf4ed85b55">

After
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/4ecbdf12-64d0-46c5-80e4-add276a20cf5">

