### PR TITLE
Fix thumbnail generation

### DIFF
--- a/themes/hub/layouts/index.json
+++ b/themes/hub/layouts/index.json
@@ -9,7 +9,7 @@
   {{- $imageUrl := false }}
   {{- range $match := (findRESubmatch `(?i)<img[^>]+src=["']([^"']+)["']` .Content)}}
     {{- $foundUrl := index $match 1 }}
-    {{- if and $foundUrl (not (or (strings.HasPrefix $foundUrl "http") (strings.HasPrefix $foundUrl "https"))) }}
+    {{- if and $foundUrl (not (or (strings.HasPrefix $foundUrl "http://") (strings.HasPrefix $foundUrl "https://"))) }}
       {{- $imageUrl = $foundUrl }}
       {{- break }}
     {{- end }}

--- a/themes/hub/layouts/index.json
+++ b/themes/hub/layouts/index.json
@@ -7,8 +7,12 @@
     {{- $scratch.Add "tags" (dict "title" .LinkTitle "permalink" (printf "/?%s" ((querify "q" .LinkTitle) | safeURL))) }}
   {{- end }}
   {{- $imageUrl := false }}
-  {{- with findRESubmatch `(?i)<img[^>]+src=["']([^"']+)["']` .Content 1 }}
-    {{- $imageUrl = index (index . 0) 1 }}
+  {{- range $match := (findRESubmatch `(?i)<img[^>]+src=["']([^"']+)["']` .Content)}}
+    {{- $foundUrl := index $match 1 }}
+    {{- if and $foundUrl (not (or (strings.HasPrefix $foundUrl "http") (strings.HasPrefix $foundUrl "https"))) }}
+      {{- $imageUrl = $foundUrl }}
+      {{- break }}
+    {{- end }}
   {{- end }}
   {{- if $imageUrl }}
     {{- $imageUrl = (.Resources.GetMatch $imageUrl).RelPermalink }}


### PR DESCRIPTION
## Motivation

Our thumbnail generation logic causes a Hugo build error when images outside the repository are used.
This PR fixes this error.

Note that images outside the repository often appear in README.md, e.g., badges like below.
https://colab.research.google.com/assets/colab-badge.svg
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1451dfd3-c1a3-48c9-a387-412f387c3002">


## Description of the changes

- Add a logic to skip `src` values starting with "http://" and "https://" not to generate thumbnails by using images outside of this repository.