### PR TITLE
Fix last update

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Checkout Registry
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           repository: optuna/optunahub-registry
           path: optunahub-registry
 


### PR DESCRIPTION
## Motivation

I noticed that "Last update" is not working as expected (i.e., Last update: 2024-08-01 is shown for all packages).
https://hub.optuna.org/
<img width="1324" alt="image" src="https://github.com/user-attachments/assets/2cba7643-b787-42af-bcf6-09458825c46b">

This PR fixes the bug.

## Description of the changes

- Setting `fetch-depth: 0` for github actions (cf. [Why latest commit date is not working in Github workflow?](https://stackoverflow.com/questions/70659016/why-latest-commit-date-is-not-working-in-github-workflow))