### PR TITLE
Disable share buttons in 404

### DIFF
--- a/themes/hub/layouts/partials/header.html
+++ b/themes/hub/layouts/partials/header.html
@@ -27,10 +27,12 @@
     <li class="nav-item"><a href="{{ printf "/?%s" ((querify "q" .LinkTitle) | safeURL) }}" class="badge text-primary border border-primary">{{ .LinkTitle }}</a></li>
     {{- end }}
   </ul>
+  {{- if not (eq .Kind "404") }}
   <ul class="nav gap-1 justify-content-end">
     <li class="nav-item"><a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-hashtags="OptunaHub">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></li>
     <li class="nav-item linkedin-share-button"><script src="https://platform.linkedin.com/in.js" type="text/javascript"></script><script type="IN/Share" data-url="{{ .Permalink }}"></script></li>
   </ul>
+  {{- end }}
 </header>
 {{- else }}
 <header class="container pt-3">


### PR DESCRIPTION
## Motivation & Description of the changes

- Disable share buttons in the 404 page

Before
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/4bf5b7a1-a482-43f2-91ce-78b7bebe4666">

After
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/6b6b62de-2a0c-4173-9015-38ee75d20cd3">
