### PR TITLE
Fix missing search results after pagination.

### DIFF
--- a/themes/hub/assets/js/search.js
+++ b/themes/hub/assets/js/search.js
@@ -5,6 +5,7 @@ const app = createApp({
     const query = ref(new URLSearchParams(location.search).get('q') || '');
     const fuse = ref(null);
     const docs = computed(() => {
+      page.value = 1
       if (fuse.value) {
         return fuse.value.search(query.value || '!^');
       }


### PR DESCRIPTION
## Motivation:

In the current implementation, when users use both search queries and pagination buttons, some search results may be excluded unexpectedly. 

Querying "gaussian" on the first page:
<img width="1382" alt="image" src="https://github.com/user-attachments/assets/8ce6300e-3802-42db-868f-1723a53afb3c">

Querying "gaussian" on the second page:
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/896e11b8-5a7b-4af5-a087-4efbcfbecad5">



This PR aims to resolve this issue and ensure that search results are displayed completely.

## Description of the Changes:

This PR addresses the aforementioned issue by implementing a change suggested by [@ofk](https://github.com/ofk). Specifically, this PR resets the page number to the first page before executing the search query.

Querying "gaussian" on the second page:
<img width="1360" alt="image" src="https://github.com/user-attachments/assets/d50fd963-6e52-48c8-aa66-ace8ff0fd1d4">
