### PR TITLE
Provide `requirements.txt` at hub.optuna.org

### DIFF
--- a/hugo_build.py
+++ b/hugo_build.py
@@ -25,6 +25,11 @@ def main() -> None:
             if os.path.exists(imgdir):
                 shutil.copytree(imgdir, f"{hugo_dir}/images", dirs_exist_ok=True)
 
+            # Copy requirements.txt if exists.
+            reqfile = f"{registry_dir}/{c}/{p}/requirements.txt"
+            if os.path.exists(reqfile):
+                shutil.copy2(reqfile, hugo_dir)
+
             # Read README.md and create index.md from it with modifications.
             with open(f"{registry_dir}/{c}/{p}/README.md", "r") as readme_md:
                 contents = frontmatter.load(readme_md)


### PR DESCRIPTION
## Motivation

Currently, some packages show the installation as follows:

```console
pip install -r https://raw.githubusercontent.com/optuna/optunahub-registry/main/package/samplers/name/requirements.txt
```

The URL of `requirements.txt` is a bit long and may be shortened if hub.optuna.org provides it. The following command will be more human-friendly.

```console
pip install -r https://hub.optuna.org/samplers/name/requirements.txt
```


## Description of the changes

- Copy `requirements.txt` to the contents of hub.optuna.org.