### PR TITLE
Introduce a default image for og:image

### DIFF
--- a/themes/hub/layouts/partials/head.html
+++ b/themes/hub/layouts/partials/head.html
@@ -23,6 +23,8 @@
 {{- $imageUrl := partial "thumbnail.html" . }}
 {{- if $imageUrl }}
 <meta property="og:image" content="{{ absURL $imageUrl }}">
+{{- else }}
+<meta property="og:image" content="{{ absURL (resources.Get "img/optuna-logo@3x.png").RelPermalink }}">
 {{- end }}
 <meta name="twitter:card" content="summary_large_image">
 <title>{{ $title }}</title>


### PR DESCRIPTION
## Motivation & Description of the changes

This PR introduces a default image for og:image.
With this PR, if a package has no image in README, the Optuna logo is used for its thumbnail for SNS share links.