### PR TITLE
Add benchmarks category

### DIFF
--- a/hugo_build.py
+++ b/hugo_build.py
@@ -13,7 +13,7 @@ def main() -> None:
 
     package_dir = "package"
     registry_dir = f"optunahub-registry/{package_dir}"
-    categories = ["samplers", "pruners", "visualization"]
+    categories = ["samplers", "pruners", "visualization", "benchmarks"]
     for c in categories:
         packages = os.listdir(f"{registry_dir}/{c}")
         for p in packages:

--- a/themes/hub/layouts/_default/home.html
+++ b/themes/hub/layouts/_default/home.html
@@ -12,6 +12,7 @@
       <li class="nav-item"><a class="badge text-primary border border-primary" href="?q=Sampler">Sampler</a></li>
       <li class="nav-item"><a class="badge text-primary border border-primary" href="?q=Visualization">Visualization</a></li>
       <li class="nav-item"><a class="badge text-primary border border-primary" href="?q=Pruner">Pruner</a></li>
+      <li class="nav-item"><a class="badge text-primary border border-primary" href="?q=Benchmark">Benchmark</a></li>
     </ul>
     <div class="row">
       <div class="col-12 col-md-6 mt-4 d-flex" v-for="doc in pageDocs">


### PR DESCRIPTION
## Motivation & Description of the changes
- Add benchmarks category to the OptunaHub website.

Please merge this PR after releasing `optunahub.benchmarks` and at least one benchmark package (e.g. https://github.com/optuna/optunahub-registry/pull/207).

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/fd54abe4-ad03-4665-81c2-cf30024c531b">
