### PR TITLE
Add MathJax support

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -20,6 +20,13 @@ enableRobotsTXT = true
   [markup.highlight]
     guessSyntax = true
     style = 'friendly'
+  [markup.goldmark]
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['$$', '$$']]
+          inline = [['$', '$'], ['$`', '`$']]
 
 [module]
   [module.hugoVersion]

--- a/themes/hub/layouts/partials/head.html
+++ b/themes/hub/layouts/partials/head.html
@@ -33,4 +33,5 @@
 <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+{{ partialCached "head/math.html" . }}
 {{ partialCached "head/css.html" . }}

--- a/themes/hub/layouts/partials/head/math.html
+++ b/themes/hub/layouts/partials/head/math.html
@@ -1,0 +1,13 @@
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+<script>
+  MathJax = {
+    tex: {
+      packages: {'[+]': ['mathtools']},
+      displayMath: [['$$', '$$']],  // block
+      inlineMath: [['$', '$'], ['$`', '`$']]  // inline
+    },
+    loader:{
+      load: ['ui/safe', '[tex]/mathtools']
+    },
+  };
+</script>


### PR DESCRIPTION
## Motivation & Description of the changes
This PR adds MathJax support on the OptunaHub web.

<img width="1423" height="764" alt="image" src="https://github.com/user-attachments/assets/0f840a4c-3f60-4aaf-bc25-f15b3b2a4933" />
