### PR TITLE
Add copy button

### DIFF
--- a/themes/hub/assets/css/main.css
+++ b/themes/hub/assets/css/main.css
@@ -26,8 +26,53 @@ h1, h2, h3, h4, h5, h6,
   font-family: Montserrat, var(--bs-body-font-family);
 }
 
+.highlight {
+  position: relative;
+}
+
 .highlight pre {
   padding: 0.25rem 0.5rem;
+}
+
+.copy-code-btn {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  color: #555;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+.highlight:hover .copy-code-btn {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .copy-code-btn {
+    opacity: 1;
+  }
+}
+
+.copy-code-btn:hover {
+  background: #fff;
+  color: #184786;
+  border-color: #184786;
+}
+
+.copy-code-btn.copied {
+  color: #198754;
+  border-color: #198754;
+  opacity: 1;
 }
 
 li.linkedin-share-button > span {

--- a/themes/hub/layouts/_default/baseof.html
+++ b/themes/hub/layouts/_default/baseof.html
@@ -10,5 +10,6 @@
     {{ block "main" . }}{{ end }}
   </main>
   {{ partial "footer.html" . }}
+  {{ partial "copy-code.html" . }}
 </body>
 </html>

--- a/themes/hub/layouts/partials/copy-code.html
+++ b/themes/hub/layouts/partials/copy-code.html
@@ -1,0 +1,34 @@
+<script>
+(function () {
+  function addCopyButtons() {
+    document.querySelectorAll('.highlight').forEach(function (block) {
+      var btn = document.createElement('button');
+      btn.className = 'copy-code-btn';
+      btn.setAttribute('aria-label', 'Copy code');
+      btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+
+      block.style.position = 'relative';
+      block.appendChild(btn);
+
+      btn.addEventListener('click', function () {
+        var code = block.querySelector('code');
+        var text = code ? code.textContent : '';
+        navigator.clipboard.writeText(text).then(function () {
+          btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+          btn.classList.add('copied');
+          setTimeout(function () {
+            btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+            btn.classList.remove('copied');
+          }, 2000);
+        });
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', addCopyButtons);
+  } else {
+    addCopyButtons();
+  }
+})();
+</script>


### PR DESCRIPTION
## Motivation & Description of the changes

This pull request adds support for the copy button in code blocks. This makes using sample code and BibTeX much easier.

When you hover over a code block, a button will appear; clicking it will copy the code. On mobile devices where hovering over a code block is not available, the button will always be displayed.

<img width="1126" height="313" alt="image" src="https://github.com/user-attachments/assets/3fe7055a-4f6f-4a93-a8d4-fbfd776f0def" />
<img width="1118" height="340" alt="image" src="https://github.com/user-attachments/assets/fd774814-ffba-4ab7-b1a4-7fe940a390d7" />
