### PR TITLE
Show dependencies based on requirements.txt

### DIFF
--- a/hugo_build.py
+++ b/hugo_build.py
@@ -26,9 +26,12 @@ def main() -> None:
                 shutil.copytree(imgdir, f"{hugo_dir}/images", dirs_exist_ok=True)
 
             # Copy requirements.txt if exists.
+            reqs = None
             reqfile = f"{registry_dir}/{c}/{p}/requirements.txt"
             if os.path.exists(reqfile):
                 shutil.copy2(reqfile, hugo_dir)
+                with open(reqfile, "r") as req_f:
+                    reqs = [pkg for line in req_f if (pkg := line.split("#")[0].strip())]
 
             # Read README.md and create index.md from it with modifications.
             with open(f"{registry_dir}/{c}/{p}/README.md", "r") as readme_md:
@@ -44,6 +47,8 @@ def main() -> None:
                         updated_at_epoch
                     ).isoformat()
                     contents["updated_at"] = updated_at_iso
+                    if reqs is not None:
+                        contents["requirements"] = reqs
                     index_md.write(frontmatter.dumps(contents))
 
 

--- a/themes/hub/layouts/_default/single.html
+++ b/themes/hub/layouts/_default/single.html
@@ -21,6 +21,16 @@
           {{- end -}}
         </ul>
       </dd>
+      {{- if .Params.requirements }}
+      <dt>Dependencies <a href="/{{ $packageName }}/requirements.txt">(.txt)</a></dt>
+      <dd>
+        <ul class="m-0 ps-3" style="max-height: 10rem; overflow-y: auto;">
+          {{- range .Params.requirements -}}
+          <li>{{ . }}</li>
+          {{- end -}}
+        </ul>
+      </dd>
+      {{- end }}
       <dt>Last update</dt>
       <dd>{{ time.Format "2006-01-02" (time.AsTime .Params.updated_at) }}</dd>
       <dt>Discussions & Issues</dt>


### PR DESCRIPTION
## Motivation & Description of the changes
Show dependencies based on `requirements.txt`. Resolve #41.
If there are many packages, you can scroll to view them.

Example for https://hub.optuna.org/samplers/gp_pims/.

<img width="428" height="292" alt="image" src="https://github.com/user-attachments/assets/0d052ed3-214d-49ca-9034-876fb80cd9e7" />