### PR TITLE
Add callback category

### DIFF
--- a/hugo_build.py
+++ b/hugo_build.py
@@ -13,7 +13,7 @@ def main() -> None:
 
     package_dir = "package"
     registry_dir = f"optunahub-registry/{package_dir}"
-    categories = ["samplers", "pruners", "visualization", "benchmarks"]
+    categories = ["samplers", "pruners", "visualization", "benchmarks", "callbacks"]
     for c in categories:
         packages = os.listdir(f"{registry_dir}/{c}")
         for p in packages:

--- a/themes/hub/layouts/_default/home.html
+++ b/themes/hub/layouts/_default/home.html
@@ -13,6 +13,7 @@
       <li class="nav-item"><a class="badge text-primary border border-primary" href="?q=Visualization">Visualization</a></li>
       <li class="nav-item"><a class="badge text-primary border border-primary" href="?q=Pruner">Pruner</a></li>
       <li class="nav-item"><a class="badge text-primary border border-primary" href="?q=Benchmark">Benchmark</a></li>
+      <li class="nav-item"><a class="badge text-primary border border-primary" href="?q=Callback">Callback</a></li>
     </ul>
     <div class="row">
       <div class="col-12 col-md-6 mt-4 d-flex" v-for="doc in pageDocs">


### PR DESCRIPTION
# Motivation

OptunaHub and optunahub-registry now support a new Callback category.
To reflect this update, optunahub-web should display the Callback category label at the top of the page and allow users to view items in this category.

# Description of the changes

* Added the Callback category to the source.
* Added a Callback badge at the top of the page.
* Enabled optunahub-web to display the Callback category.