### PR TITLE
Remove videos from menu

### DIFF
--- a/themes/hub/layouts/partials/navbar.html
+++ b/themes/hub/layouts/partials/navbar.html
@@ -27,9 +27,6 @@
           <a class="nav-link" href="https://optuna.org/#blog">Blog</a>
         </li>
         <li class="nav-item text-center fw-bold">
-          <a class="nav-link" href="https://optuna.org/#video">Videos</a>
-        </li>
-        <li class="nav-item text-center fw-bold">
           <a class="nav-link" href="https://optuna.org/#papers">Papers</a>
         </li>
       </ul>


### PR DESCRIPTION
## Motivation & Description of the changes

Remove the "Videos" section from the menu, as it no longer exists on optuna.org.